### PR TITLE
Fancyintl

### DIFF
--- a/app/assets/stylesheets/components/_login_form.scss
+++ b/app/assets/stylesheets/components/_login_form.scss
@@ -35,6 +35,10 @@
   }
 }
 
+.iti {
+  width: 100%;
+}
+
 // STEP 1
 
 .user_first_name {

--- a/app/assets/stylesheets/components/_login_form.scss
+++ b/app/assets/stylesheets/components/_login_form.scss
@@ -35,8 +35,18 @@
   }
 }
 
+//  INITIAL STEP
+
 .iti {
   width: 100%;
+}
+
+#intl-error-msg {
+  margin-top: -1em;
+  margin-bottom: 1em;
+  width: 100%;
+  font-size: 80%;
+  color: #dc3545;
 }
 
 // STEP 1

--- a/app/javascript/plugins/intl.js
+++ b/app/javascript/plugins/intl.js
@@ -1,13 +1,38 @@
 import intlTelInput from 'intl-tel-input';
 
 const input = document.querySelector("#user_phone_number");
-if (input) {
-  intlTelInput(input, {
-    formatOnInit: true,
-    separateDialCode: true,
-    autoPlaceholder: "aggressive",
-    onlyCountries: ['at', 'be', 'bg', 'cz', 'dk', 'de', 'ee', 'ie', 'el', 'es', 'fr', 'hr', 'it', 'cy', 'lv', 'lt', 'lu', 'hu', 'mt', 'nl', 'pl', 'pt', 'ro', 'si', 'sk', 'fi', 'se', 'uk'],
-    initialCountry: "es",
-  });
-}
+const errorMsg = document.querySelector("#intl-error-msg");
+const validMsg = document.querySelector("#intl-valid-msg");
+const errorMap = ["Invalid number", "Invalid country code", "Too short", "Too long", "Invalid number"];
 
+const iti = intlTelInput(input, {
+  formatOnInit: true,
+  separateDialCode: true,
+  autoPlaceholder: "aggressive",
+  preferredCountries: ['at', 'be', 'bg', 'cz', 'dk', 'de', 'ee', 'ie', 'el', 'es', 'fr', 'hr', 'it', 'cy', 'lv', 'lt', 'lu', 'hu', 'mt', 'nl', 'pl', 'pt', 'ro', 'si', 'sk', 'fi', 'se', 'uk'],
+  initialCountry: "es",
+});
+
+const reset = function() {
+  input.classList.remove("error");
+  errorMsg.innerHTML = "";
+  errorMsg.classList.add("hidden");
+  validMsg.classList.add("hidden");
+};
+
+input.addEventListener('blur', function() {
+  reset();
+  if (input.value.trim()) {
+    if (iti.isValidNumber()) {
+    // do nothing if valid, let it pass
+    } else {
+      input.classList.add("error");
+      var errorCode = iti.getValidationError();
+      errorMsg.innerHTML = errorMap[errorCode];
+      errorMsg.classList.remove("hidden");
+    }
+  }
+});
+
+input.addEventListener('change', reset);
+input.addEventListener('keyup', reset);

--- a/app/javascript/plugins/intl.js
+++ b/app/javascript/plugins/intl.js
@@ -5,6 +5,7 @@ if (input) {
   intlTelInput(input, {
     formatOnInit: true,
     separateDialCode: true,
+    autoPlaceholder: "aggressive",
     onlyCountries: ['at', 'be', 'bg', 'cz', 'dk', 'de', 'ee', 'ie', 'el', 'es', 'fr', 'hr', 'it', 'cy', 'lv', 'lt', 'lu', 'hu', 'mt', 'nl', 'pl', 'pt', 'ro', 'si', 'sk', 'fi', 'se', 'uk'],
     initialCountry: "es",
   });

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   validates :phone_number, presence: true,
                            numericality: true,
-                           length: { minimum: 10, maximum: 15 }
+                           length: { minimum: 8, maximum: 15 }
 
   validates :first_name, :last_name, :address, :country, :place_of_birth, :birthday, :gender, :height, :weight, presence: true, if: :active_or_step1?
   validates :level, :style_of_play, :handedness, :backhand_style, presence: true, if: :active_or_step2?

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,10 +24,8 @@
                   <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
                 <% end %>
                 <%= f.input :phone_number,
-                            label: "ENTER YOUR PHONE NUMBER",
-                            placeholder: "example: +34",
                             as: :tel,
-                            pattern: "[0-9]+" %>
+                            pattern: "\+[0-9]+" %>
                 <%= f.input :password,
                       hint: "leave it blank if you don't want to change it",
                       required: false,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,7 +15,6 @@
                       label: "YOUR EMAIL" %>
           <%= f.input :phone_number,
                       label:"YOUR MOBILE PHONE NUMBER",
-                      placeholder: "let other players contact you",
                       as: :tel,
                       pattern: "[0-9]+" %>
           <%= f.input :password,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,7 +16,9 @@
           <%= f.input :phone_number,
                       label:"YOUR MOBILE PHONE NUMBER",
                       as: :tel,
-                      pattern: "[0-9]+" %>
+                      pattern: "\+[0-9]+" %>
+          <p id="intl-valid-msg" class="hidden">Valid</p>
+          <p id="intl-error-msg" class="hidden"></p>
           <%= f.input :password,
                       required: true,
                       hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,5 +33,5 @@
   <%= render 'shared/footer' %>
   <% end %>
 </footer>
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.2/js/utils.js" integrity="sha256-0j199Z187LMKPysQFGVwcQ3At8V3Qg6PD0bOD50+gu4=" crossorigin="anonymous"></script>
 </html>


### PR DESCRIPTION
@florindiconescu I have added some JS validations using mostly the documentation provided:
https://intl-tel-input.com/node_modules/intl-tel-input/examples/gen/is-valid-number.html

Things to note:
- I had to remove the initial if statement in the JS function to make validations work
- For some reason, the edit page breaks on the phone fields (adds a massive padding-left)
- For some reason too, the Active Record error message does not show anymore below the phone field
- Phone number are not persisted with the extension => problem if we want to use Whatsapp
- With plain JS, we should be able to "store" the value of extension + phone targeting the right elements. How can we then pass this to be persisted? See screenshot:

<img width="451" alt="Screenshot 2019-07-29 at 16 33 02" src="https://user-images.githubusercontent.com/8274530/62057050-1fdfc600-b21f-11e9-80c5-a5dae949ba5e.png">
