### PR TITLE
Shuffle users the right way

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,8 +32,8 @@ class UsersController < ApplicationController
   def set_seed
     seed = cookies[:user_seed].to_i || Time.now.to_i
     seconds_since_seed = Time.now - Time.at(seed)
-    expired_seed = seconds_since_seed > 30.minutes.to_i
-    no_seed = cookies[:user_seed].nil? || cookies[:user_seed].empty?
+    expired_seed = seconds_since_seed > 30.minutes
+    no_seed = cookies[:user_seed].nil? || cookies[:user_seed].blank?
     if expired_seed || no_seed
       seed = Time.now.to_i
       cookies[:user_seed] = seed

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,8 @@ class UsersController < ApplicationController
       @users = User.active
       update_ranking
     end
-    @users = @users.order(Arel.sql("RANDOM()")).paginate(page: params[:page], per_page: 12)
+    seed = set_seed
+    @users = @users.select(["setseed(.#{seed})", '*']).order(Arel.sql("RANDOM()")).paginate(page: params[:page], per_page: 12)
     respond_to :html, :js
   end
 
@@ -27,6 +28,18 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def set_seed
+    seed = cookies[:user_seed].to_i || Time.now.to_i
+    seconds_since_seed = Time.now - Time.at(seed)
+    expired_seed = seconds_since_seed > 30.minutes.to_i
+    no_seed = cookies[:user_seed]&.empty?
+    if expired_seed || no_seed
+      seed = Time.now.to_i
+      cookies[:user_seed] = seed
+    end
+    return seed
+  end
 
   def format_query(params)
     return unless params[:query].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
     seed = cookies[:user_seed].to_i || Time.now.to_i
     seconds_since_seed = Time.now - Time.at(seed)
     expired_seed = seconds_since_seed > 30.minutes.to_i
-    no_seed = cookies[:user_seed]&.empty?
+    no_seed = cookies[:user_seed].nil? || cookies[:user_seed].empty?
     if expired_seed || no_seed
       seed = Time.now.to_i
       cookies[:user_seed] = seed


### PR DESCRIPTION
To give you an idea, I found a way of having random set of users + pagination:
- I am storing a number in cookies (Time.now.to_i).
- I am serving this number as a seed for the `order(RANDOM())` method (is specific for PostgreSQL), which means that as long as I serve this number, the same order will be used for the users collection. This allows you to scroll and access the index method again and again without repeating users.
- I expire the number after 30 minutes, so once in a while the content gets refreshed and you won't see always the same order of users.
We can change 30 minutes to a different time if needed.
Let me know if something is not clear.