### PR TITLE
Fix search by club

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,8 +22,7 @@ class UsersController < ApplicationController
   end
 
   def rankings
-    @users = User.active.ordered_by_points
-    update_ranking
+    @users = User.active.order(ranking: :asc)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,6 @@ class UsersController < ApplicationController
       @users = SearchUsers.new(params[:search]).call
     else
       @users = User.active
-      update_ranking
     end
     @users = @users.order(Arel.sql("RANDOM()")).paginate(page: params[:page], per_page: 12)
     respond_to :html, :js
@@ -36,10 +35,6 @@ class UsersController < ApplicationController
   def set_query_indication
     location = params[:search].try(:[], :location)
     @indication = location.present? ? t('.search_results_location', location: location) : t('.matching_query')
-  end
-
-  def update_ranking
-    @users.ordered_by_points.each_with_index { |user, index| user.update(ranking: index + 1) }
   end
 
   def calculate_progressbar(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,7 @@ class User < ApplicationRecord
 
   include PgSearch
   pg_search_scope :search_user_fields,
-                  against: %i[address level first_name last_name style_of_play gender country handedness backhand_style club_id],
+                  against: %i[address level first_name last_name style_of_play gender country handedness backhand_style],
                   using: {
                     tsearch: { prefix: true }
                   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   reverse_geocoded_by :latitude, :longitude
   after_validation :geocode, if: :will_save_change_to_address?
 
+  after_save :update_ranking
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :confirmable,
@@ -169,5 +171,9 @@ class User < ApplicationRecord
 
   def subscribe_to_newsletter
     SubscribeToNewsletterService.new(self).call if Rails.env.production?
+  end
+
+  def update_ranking
+    User.active.ordered_by_points.each_with_index { |user, index| user.update(ranking: index + 1) }
   end
 end

--- a/app/queries/search_users.rb
+++ b/app/queries/search_users.rb
@@ -8,6 +8,7 @@ class SearchUsers
   def call
     @scope = filter_by_text(@scope, params[:query]) if params[:query].present?
     @scope = filter_by_location(@scope, params[:location]) if params[:location].present?
+    @scope = filter_by_club(@scope, params[:club]) if params[:club].present?
     @scope
   end
 
@@ -19,5 +20,9 @@ class SearchUsers
 
   def filter_by_location(scope, location)
     scope.near(location, 10)
+  end
+
+  def filter_by_club(scope, club_id)
+    scope.where(club_id: club_id)
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -42,7 +42,7 @@
           </button>
         </div>
         <div class="modal-body">
-          <%= f.input :club, required: false, collection: Club.all, input_html: {name: "search[query][]", class: "select-club"}, label: t('.club') %>
+          <%= f.input :club, required: false, collection: Club.all, input_html: {name: "search[club]", class: "select-club"}, label: t('.club') %>
           <%= f.input :location, required: false, input_html: {name: "search[location]", value: params[:search].try(:[], :location)}, id: "search_location", as: :string, label: t('.location') %>
           <%= f.input :country, input_html: {name: "search[query][]", class: "select-country"}, label: t('.country') %>
           <%= f.input :level, as: :check_boxes, required: false, input_html: {name: "search[query][]"}, collection: User.levels, wrapper: :vertical_collection_inline, label: t('.level') %>


### PR DESCRIPTION
I have refactored the club filtering as it should be - with a dedicated method in the search model, and keeping it out of the pg search scope, as rails is equally fast in finding by id.

Secondly, I have refactored the `ranking` method in users controller - so it will always reflect a correct ranking from the database.

Lastly, I have taken out the `update_ranking` method from users controller, and added it into the model, where it belongs. I followed the logic that the ranking has to be calculated in 2 moments: when a user is created, or when a users is updated(because it was reviewed). This is why I call the `update_ranking` method with an `after_save` callback, as this is running in both cases - create and update.

I have fully tested the search by club and I have all the reasons to believe it should not be wrong.

The same I believe for update ranking method, but I haven't tested that much. Can you please merge and try locally to add new users and review players, and make sure the ranking page is still correct, while no error is coming?