### PR TITLE
removed callback and call the method only when necessary

### DIFF
--- a/app/controllers/user_steps_controller.rb
+++ b/app/controllers/user_steps_controller.rb
@@ -22,6 +22,7 @@ class UserStepsController < ApplicationController
       step3
     end
     @user.update_attributes(user_params)
+    User.update_ranking if @user.active?
     render_wizard @user
   end
 

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -15,6 +15,7 @@ class MatchResult < ApplicationRecord
     the_match.player_2.points = points.calculate_player_2_points
     the_match.player_1.save
     the_match.player_2.save
+    User.update_ranking
   end
 
   def update_players_levels

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,6 @@ class User < ApplicationRecord
   reverse_geocoded_by :latitude, :longitude
   after_validation :geocode, if: :will_save_change_to_address?
 
-  after_save :update_ranking
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :confirmable,
@@ -163,6 +161,10 @@ class User < ApplicationRecord
     !deleted_at ? super : :deleted_account
   end
 
+  def self.update_ranking
+    User.active.ordered_by_points.each_with_index { |user, index| user.update(ranking: index + 1) }
+  end
+
   private
 
   def set_skills
@@ -171,9 +173,5 @@ class User < ApplicationRecord
 
   def subscribe_to_newsletter
     SubscribeToNewsletterService.new(self).call if Rails.env.production?
-  end
-
-  def update_ranking
-    User.active.ordered_by_points.each_with_index { |user, index| user.update(ranking: index + 1) }
   end
 end


### PR DESCRIPTION
I have removed the callback in the user model, and moved the `update_ranking` method in the public methods.
Secondly, I am now calling this method manually in the following 2 cases:
 - after a user becomes `active`;
 - after a match is confirmed and the players points are updated.
In both cases it works perfectly - tested by me. Please try and you can push to production if you're happy.

Now I have two questions:
1) Do you know another action which should trigger an update of the ranking afterwards?
2) Do you know how to call this method as a sidekick job?